### PR TITLE
Chrome Web Store compliance: extension name change 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
   "manifest_version": 2,
   "name": "Unofficial Google Books Right-Click Search",
   "short_name": "GB Search",
-  "description": "Search for selected text on Google Books via right-click and see the results in a new tab. This extension is not an official product.",
+  "description": "Search selected text on Google Books via right-click and see the results in a new tab. This extension is not an official product.",
   "permissions": ["contextMenus"],
   "version": "1.1.1"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
       "16": "images/16.png",
       "32": "images/32.png"
     },
-    "default_title": "Google Books Right-Click Search"
+    "default_title": "Unofficial Google Books Right-Click Search"
   },
   "icons": {
     "16": "images/16.png",
@@ -16,9 +16,9 @@
     "128": "images/128.png"
   },
   "manifest_version": 2,
-  "name": "Google Books Right-Click Search",
+  "name": "Unofficial Google Books Right-Click Search",
   "short_name": "GB Search",
-  "description": "Search for selected text on Google Books via right-click and see the results in a new  tab",
+  "description": "This extension is not a product by Google. Search for selected text on Google Books via right-click and see the results in a new tab.",
   "permissions": ["contextMenus"],
   "version": "1.1.0"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
   "manifest_version": 2,
   "name": "Unofficial Google Books Right-Click Search",
   "short_name": "GB Search",
-  "description": "This extension is not a product by Google. Search for selected text on Google Books via right-click and see the results in a new tab.",
+  "description": "Search for selected text on Google Books via right-click and see the results in a new tab. This extension is not an official product.",
   "permissions": ["contextMenus"],
-  "version": "1.1.0"
+  "version": "1.1.1"
 }


### PR DESCRIPTION
This pull request changes the name of the extension in manifest.json file to comply with Chrome Web Store terms. The following violation was found by Chrome Web Store:

Violation reference ID: Red Nickel
Violation: Impersonating or mimicking the following entity through item’s metadata/UI

This pull request also updates extension version in manifest.json from 1.1.0 to 1.1.1 and explicitly adds to the description the disclaimer that the extension is not an official product.